### PR TITLE
Make the Parallel Computing Toolbox optional for model computation

### DIFF
--- a/classes/Model.m
+++ b/classes/Model.m
@@ -459,7 +459,11 @@ classdef Model < Descriptions
             validationIterationLoop = @obj.validationIterationLoop;
             n = data(1).testingSteps;
             if n > 1
-                isparallel = ~isempty(getCurrentTask());
+                try
+                    isparallel = ~isempty(getCurrentTask());
+                catch
+                    isparallel = false;
+                end
                 if ~isparallel
                     d(n,numel(data)) = Data();
                     for i = 1:numel(data)
@@ -500,7 +504,11 @@ classdef Model < Descriptions
             validationStepLoop = @obj.validationStepLoop;
             n = data(1).validationIterations;
             if n > 1
-                isparallel = ~isempty(getCurrentTask());
+                try
+                    isparallel = ~isempty(getCurrentTask());
+                catch
+                    isparallel = false;
+                end
                 if ~isparallel
                     d(n,numel(data)) = Data();
                     for i = 1:numel(data)
@@ -539,7 +547,11 @@ classdef Model < Descriptions
             hyperParametersLoop = @obj.hyperParametersLoop;
             n = data(1).validationSteps;
             if n > 1
-                isparallel = ~isempty(getCurrentTask());
+                try
+                    isparallel = ~isempty(getCurrentTask());
+                catch
+                    isparallel = false;
+                end
                 if ~isparallel
                     d(n,numel(data)) = Data();
                     for i = 1:numel(data)


### PR DESCRIPTION
Currently, no parallel computing is used during model computation.
There are, however, structures in place for it to be used in the
future. Specifically, each level of the nested computation (validation,
testing, both folds and iterations) checks if a parfor loop is already
running. This check is necessary due to issues with nested parfor
loops. Currently, the result of the check will always be false because
no parfor loop is used. The check itself, however, involves a call to
getCurrentTask() which is only available through the Parallel Computing
Toolbox. Thus, no model can be computed without it.

This commit wraps each of these checks in a try/catch and returns false
if it fails. In this way, model computation is possible without PCT
installed.

Fixes #5.