### PR TITLE
Fixed performance issue concerning colors in tables in Grouping and Cycles Ranges tab

### DIFF
--- a/+Gui/+Modules/CycleRanges.m
+++ b/+Gui/+Modules/CycleRanges.m
@@ -343,12 +343,15 @@ classdef CycleRanges < Gui.Modules.GuiModule
             if obj.clusterHasChanged()
                 obj.handleClusterChange(obj.getProject().getCurrentCluster(),obj.lastCluster);
             end
+
             if obj.sensorHasChanged()
                 obj.handleSensorChange(obj.getProject().getCurrentSensor(),obj.lastSensor);
             end
+
             if ~isequal(obj.getProject().ranges, obj.ranges)
                 obj.handleClusterChange(obj.getProject().getCurrentCluster(),obj.lastCluster);
             end
+
             obj.ranges.updateYLimits();
 %             set(obj.main.hFigure,'WindowScrollWheelFcn',@obj.scrollWheelCallback);
         end
@@ -448,6 +451,9 @@ classdef CycleRanges < Gui.Modules.GuiModule
                 ind = tableColSort(t,4,'a');
                 gRanges = gRanges(ind);
             end
+
+            removeStyle(t)
+
             if ~isempty(data)
                 clrArray = clrArray(ind,:); %sort colors, then style
                 if size(clrArray,1) > 1

--- a/+Gui/+Modules/Grouping.m
+++ b/+Gui/+Modules/Grouping.m
@@ -374,6 +374,8 @@ classdef Grouping < Gui.Modules.GuiModule
             t.ColumnFormat = {'char','char'};
             t.ColumnEditable = [true true];
             
+            removeStyle(t)
+
             if size(clrArray,1) > 1
                 for i = 1:size(clrArray,1)
                     s = uistyle('BackgroundColor',clrArray(i,:));


### PR DESCRIPTION
New colors were created everytime one of the tabs were loaded, but nevere deleted. This lead to an increase in loading time everytime the tabs were opened. The simple fix was to just delete the colors when the tabs were opened